### PR TITLE
In memory testing

### DIFF
--- a/Endpoints/database.rb
+++ b/Endpoints/database.rb
@@ -1,10 +1,21 @@
-DATABASE = 'minitwit.db'
 SCHEMA_PATH = 'schema.sql'
+
+# Configuration for in memory testing
+DATABASE = if ENV['RACK_ENV'] == 'test'
+  ':memory:'
+else
+  'minitwit.db'
+end
 
 # Database connection
 def connect_db
   db = SQLite3::Database.new(DATABASE)
   db.results_as_hash = true #Allows accessing record fields by their name
+  if DATABASE == ':memory:'
+     # Initialize schema for in-memory database
+     sql = File.read(SCHEMA_PATH)
+     db.execute_batch(sql)
+  end
   db
 end
 

--- a/Logbook.md
+++ b/Logbook.md
@@ -21,6 +21,7 @@ Date: 2025, wed Feb 20, 20:04:05 UTC+1
 In memory testing for SQLite3
 
 Setup in memory testing by setting database path depending on enviroment variable that can be set from test.
+Application has not been setup to launch automatically when running tests and application should therefore be hosted manually for testing.
 
 ---
 

--- a/Logbook.md
+++ b/Logbook.md
@@ -13,7 +13,14 @@ Date: (year), (day of the week) (month) (day), (time) (timezone)
 
 (changes)
 
+---
 
+Author: nals, <nals@itu.dk> <br>
+Date: 2025, wed Feb 20, 20:04:05 UTC+1
+
+In memory testing for SQLite3
+
+Setup in memory testing by setting database path depending on enviroment variable that can be set from test.
 
 ---
 

--- a/Test/minitwit_tests_spec.rb
+++ b/Test/minitwit_tests_spec.rb
@@ -1,6 +1,19 @@
 ﻿require 'rspec'
 require 'rest-client'
 require 'json'
+require 'rack/test'
+require 'sqlite3'
+
+ENV['RACK_ENV'] = 'test'
+require_relative '../minitwit'  # Load the main Sinatra app
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+end
 
 BASE_URL = 'http://localhost:5000'
 


### PR DESCRIPTION
In memory testing for SQLite3

Setup in-memory testing by setting database path depending on enviroment variable, which can be set from test.
Application has not been setup to launch automatically when running tests, so application should therefore still be hosted manually when testing.

![billede](https://github.com/user-attachments/assets/2f7dc256-725c-4d72-a576-a222fe105464)
