### PR TITLE
Adjusted workflow run events

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -3,10 +3,9 @@ name: Continuous Deployment
 
 on:
   push:
-    # Run workflow every time something is pushed to the main branch
-    branches:
-      - main
-      - master
+    # Run workflow every time something is pushed with tags v* (v1.0, v20.15.10)
+    tags:
+      - 'v*'
   # allow manual triggers for now too
   workflow_dispatch:
     manual: true

--- a/.github/workflows/continous-testing.yml
+++ b/.github/workflows/continous-testing.yml
@@ -1,14 +1,9 @@
 name: Continuous Testing
 
 on:
-  push:
-    branches:
-      - main
-      - master
   pull_request:
     branches:
       - main
-      - master
   workflow_dispatch:
     manual: true
 


### PR DESCRIPTION
Adjusted workflow run events, such that we do not deploy every time something is pushed to main. But instead we evaluate if it has been pushed with a version tag.

Test workflow now only runs when a pull request to main has been made, but is still able to be run manually if developers desire to test their branch.