### PR TITLE
Refactor pg tables

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -21,8 +21,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    
     steps:
+      - name: Set environment variables
+        run: |
+          echo "POSTGRES_USER=${{ secrets.POSTGRES_USER }}" >> $GITHUB_ENV
+          echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> $GITHUB_ENV
+          echo "POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}" >> $GITHUB_ENV
+          echo "POSTGRES_DB=${{ secrets.POSTGRES_DB }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -42,6 +49,11 @@ jobs:
           file: ./Dockerfile.app
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/minitwitimage:latest
+          build-args: |
+            POSTGRES_USER=${{ secrets.POSTGRES_USER }}
+            POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            POSTGRES_DB=${{ secrets.POSTGRES_DB }}
+            POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwitimage:webbuildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwitimage:webbuildcache,mode=max
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -63,22 +63,10 @@ jobs:
 
       - name: Test minitwit
         run: |
-
-          # Try to pull test image first. Build it locally if it fails.
-          if docker pull $DOCKER_USERNAME/minitwit-test-image; then
-            echo "Successfully pulled test image from Docker Hub"
-          else
-            echo "Image not found in Docker Hub, building locally"
-            docker build -t $DOCKER_USERNAME/minitwit-test-image -f Dockerfile.test .
-          fi
+          # Build docker images
+          docker build -t $DOCKER_USERNAME/minitwit-test-image -f Dockerfile.test .
+          docker build -t $DOCKER_USERNAME/postgresqlimage -f Dockerfile.postgresql .
           
-          # Try to pull PG image first. Build it locally if it fails.
-          if docker pull $DOCKER_USERNAME/postgresqlimage; then
-            echo "Successfully pulled PostgreSQL image from Docker Hub"
-          else
-            echo "Image not found in Docker Hub, building locally"
-            docker build -t $DOCKER_USERNAME/postgresqlimage -f Dockerfile.postgresql .
-          fi
 
           # Run the tests
           docker compose -f docker-compose.test.yml up --exit-code-from app

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -13,6 +13,18 @@ RUN gem install bundler && bundle install
 # Expose the port the app will run on
 EXPOSE 5000
 
+# Accept build arguments for environment variables
+ARG POSTGRES_USER
+ARG POSTGRES_PASSWORD
+ARG POSTGRES_DB
+ARG POSTGRES_HOST
+
+# Set environment variables inside the container
+ENV POSTGRES_USER=$POSTGRES_USER
+ENV POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+ENV POSTGRES_DB=$POSTGRES_DB
+ENV POSTGRES_HOST=$POSTGRES_HOST
+
 # Ensures data persistency
 RUN mkdir -p /app/data
 ENV DB_PATH=/app/data

--- a/Endpoints/endpoint_methods.rb
+++ b/Endpoints/endpoint_methods.rb
@@ -278,7 +278,7 @@ def get_followers(username, limit)
 
   # This finds users who follow the specified user
   # The users are the 'who_id' in the Follower table where 'whom_id' is our target user
-  User.joins("INNER JOIN followers ON users.id = followers.who_id")
+  User.joins("INNER JOIN followers ON users.user_id, = followers.who_id")
     .where(followers: {whom_id: user_id})
     .limit(limit)
 end

--- a/Endpoints/endpoint_methods.rb
+++ b/Endpoints/endpoint_methods.rb
@@ -81,7 +81,7 @@ def get_user_id(username)
   if user.nil?
     halt 404, "404 User not found"
   else
-    user.id
+    user.user_id
   end
 end
 
@@ -188,7 +188,7 @@ def login_user(username, password)
     if user.nil? || !(BCrypt::Password.new(user.pw_hash) == password)
       "Invalid username or Invalid password"
     else
-      user.id
+      user.user_id
     end
   end
 end
@@ -214,7 +214,7 @@ def follows(follower_id, followee)
   followee_user = get_user(followee)
   return false if followee_user.nil?
 
-  followee_id = followee_user.id
+  followee_id = followee_user.user_id
   Follower.exists?(who_id: followee_id, whom_id: follower_id)
 end
 
@@ -226,7 +226,7 @@ def follow(follower_id, followee)
   followee_user = get_user(followee)
   return "User #{followee} not found" if followee_user.nil?
 
-  followee_id = followee_user.id
+  followee_id = followee_user.user_id
 
   # Check if trying to follow yourself
   if followee_id == follower_id

--- a/Endpoints/endpoint_methods.rb
+++ b/Endpoints/endpoint_methods.rb
@@ -15,8 +15,8 @@ before do
   @start_time = Time.now
   Metrics.active_users.increment
 
-  @user_id = session[:id]
-  @user = @user_id.nil? ? nil : User.find_by(id: @user_id)
+  @user_id = session[:user_id]
+  @user = @user_id.nil? ? nil : User.find_by(user_id: @user_id)
   if request.path.start_with?("/api/")
     content_type :json
     update_latest(params["latest"])
@@ -250,7 +250,7 @@ def unfollow(follower_id, followee)
   followee_user = get_user(followee)
   return "User #{followee} not found" if followee_user.nil?
 
-  followee_id = followee_user.id
+  followee_id = followee_user.user_id
 
   # Check if trying to unfollow yourself
   if followee_id == follower_id
@@ -278,7 +278,7 @@ def get_followers(username, limit)
 
   # This finds users who follow the specified user
   # The users are the 'who_id' in the Follower table where 'whom_id' is our target user
-  User.joins("INNER JOIN followers ON users.user_id, = followers.who_id")
+  User.joins("INNER JOIN followers ON users.user_id = followers.who_id")
     .where(followers: {whom_id: user_id})
     .limit(limit)
 end

--- a/Endpoints/endpoints_html.rb
+++ b/Endpoints/endpoints_html.rb
@@ -32,7 +32,7 @@ post "/login" do
   @username = params["username"]
   response = login_user(@username, params["password"])
   if response.is_a?(Integer)
-    session[:id] = response.to_i
+    session[:user_id] = response.to_i
     session[:success_message] = "You were logged in"
     redirect to("/")
   else
@@ -61,7 +61,7 @@ post "/register" do
 end
 
 get "/logout" do
-  session[:id] = nil
+  session[:user_id] = nil
   session[:success_message] = "You were logged out"
   redirect to("/public")
 end

--- a/db/migrate/20250306222930_create_users.rb
+++ b/db/migrate/20250306222930_create_users.rb
@@ -1,11 +1,10 @@
 class CreateUsers < ActiveRecord::Migration[7.2]
   def change
-    create_table :users do |t|  # ActiveRecord expects `id` as primary key by default
+    create_table :users, id: false do |t|  # ActiveRecord expects `id` as primary key by default
+      t.integer :user_id, primary_key: true
       t.string :username, null: false
       t.string :email, null: false
       t.string :pw_hash, null: false
-
-      t.timestamps  # Adds created_at and updated_at columns
     end
   end
 end

--- a/db/migrate/20250306222942_create_messages.rb
+++ b/db/migrate/20250306222942_create_messages.rb
@@ -1,12 +1,11 @@
 class CreateMessages < ActiveRecord::Migration[7.2]
   def change
-    create_table :messages do |t|
+    create_table :messages, id: false do |t|
+      t.integer :message_id, primary_key: true
       t.integer :author_id, null: false
       t.string :text, null: false
       t.integer :pub_date
       t.integer :flagged, default: 0
-
-      t.timestamps  # Adds created_at and updated_at
     end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_HOST=${POSTGRES_HOST_REMOTE}
       - POSTGRES_PORT=5432
+    build-args: |
+      POSTGRES_USER=${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_DB=${{ secrets.POSTGRES_DB }}
+      POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
     command: >
       bash -c "sleep 10 && bundle exec rake db:create db:migrate && bundle exec ruby minitwit.rb -o 0.0.0.0"
   prometheus:


### PR DESCRIPTION
This pull request includes several changes to improve the deployment process and database schema. The most important changes include setting environment variables in the deployment workflow, updating the database schema to use custom primary keys, and fixing a join query in the `get_followers` method.

Improvements to deployment process:

* [`.github/workflows/continuous-deployment.yml`](diffhunk://#diff-af36bb0ba98217223305c14372a4e893c25a61dcfa63a78b32eb3f37c6cd1285R26-R32): Added steps to set environment variables and pass them as build arguments in the Docker build process. [[1]](diffhunk://#diff-af36bb0ba98217223305c14372a4e893c25a61dcfa63a78b32eb3f37c6cd1285R26-R32) [[2]](diffhunk://#diff-af36bb0ba98217223305c14372a4e893c25a61dcfa63a78b32eb3f37c6cd1285R52-R56)
* [`Dockerfile.app`](diffhunk://#diff-bab0860983a48d2768e2eb14c639b3dc6ffd0337df38ecbd2062e1fe1b7e9ed4R16-R27): Added support for accepting and setting environment variables inside the container using build arguments.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R18-R22): Added build arguments to pass environment variables for the Postgres service.

Database schema updates:

* [`db/migrate/20250306222930_create_users.rb`](diffhunk://#diff-13fe82b819a3c387bb28567c018dd63353ba1e5c351976d750d9198ca2e05902L3-L8): Modified the `users` table to use `user_id` as the primary key instead of the default `id`.
* [`db/migrate/20250306222942_create_messages.rb`](diffhunk://#diff-17be639da746e34462e40ccf148c004d764c1cb474e45ac2f57e0bd9775de48bL3-L9): Modified the `messages` table to use `message_id` as the primary key instead of the default `id`.

Bug fix:

* [`Endpoints/endpoint_methods.rb`](diffhunk://#diff-6ceeccfbe709d93f27a7ab7283e616af60c909926948e464a8d4a41c6b392d2bL281-R281): Fixed a typo in the join query for the `get_followers` method.