### PR TITLE
Fix: Aggregate all endpoint hits without username

### DIFF
--- a/Endpoints/endpoint_methods.rb
+++ b/Endpoints/endpoint_methods.rb
@@ -30,13 +30,13 @@ after do
 
   # Increment request count
   Metrics.http_requests_total.increment(
-    labels: {method: request.request_method, route: request.path, status: response.status}
+    labels: {method: request.request_method, route: env['sinatra.route'] || 'unknown', status: response.status}
   )
 
   # Track request duration
   Metrics.http_request_duration_seconds.observe(
     duration,
-    labels: {method: request.request_method, route: request.path, status: response.status}
+    labels: {method: request.request_method, route: env['sinatra.route'] || 'unknown', status: response.status}
   )
 
   # Decrease active users

--- a/Endpoints/endpoints_api.rb
+++ b/Endpoints/endpoints_api.rb
@@ -49,7 +49,7 @@ get "/api/msgs/:username" do
   duration = Time.now - start_time
   Metrics.db_get_msgs_by_user_duration.observe(
     duration,
-    labels: {endpoint: "/api/msgs/:username"}
+    labels: {endpoint: "/api/msgs"}
   )
   filter_messages(messages).to_json
 end
@@ -62,7 +62,7 @@ post "/api/msgs/:username" do
   duration = Time.now - start_time
   Metrics.db_create_msg_duration.observe(
     duration,
-    labels: {endpoint: "/api/msgs/:username"}
+    labels: {endpoint: "/api/msgs"}
   )
   if error.nil?
     status 204
@@ -78,7 +78,7 @@ get "/api/fllws/:username" do
   duration = Time.now - start_time
   Metrics.db_get_followers_by_user_duration.observe(
     duration,
-    labels: {endpoint: "/api/fllws/:username"}
+    labels: {endpoint: "/api/fllws"}
   )
   usernames = followers.map { |f| f["username"] }
   return {follows: usernames}.to_json
@@ -93,7 +93,7 @@ post "/api/fllws/:username" do
     duration = Time.now - start_time
     Metrics.db_follow_user_duration.observe(
       duration,
-      labels: {endpoint: "/api/fllws/:username"}
+      labels: {endpoint: "/api/fllws"}
     )
     if error.nil?
       return status 204
@@ -110,7 +110,7 @@ post "/api/fllws/:username" do
     duration = Time.now - start_time
     Metrics.db_unfollow_user_duration.observe(
       duration,
-      labels: {endpoint: "/api/fllws/:username"}
+      labels: {endpoint: "/api/fllws"}
     )
     if error.nil?
       return status 204

--- a/Endpoints/endpoints_api.rb
+++ b/Endpoints/endpoints_api.rb
@@ -9,6 +9,10 @@ end
 
 # API Endpoints
 
+before do
+  env['sinatra.route'] = nil
+end
+
 get "/api/latest" do
   latest = get_latest.to_i
   return {latest: latest}.to_json
@@ -42,6 +46,7 @@ get "/api/msgs" do
 end
 
 get "/api/msgs/:username" do
+  env['sinatra.route'] = '/api/msgs/:username'
   user_id = get_user_id(params[:username])
   limit = get_param_or_default("no", 100)
   start_time = Time.now
@@ -55,6 +60,7 @@ get "/api/msgs/:username" do
 end
 
 post "/api/msgs/:username" do
+  env['sinatra.route'] = '/api/msgs/:username'
   user_id = get_user_id(params[:username])
   message = @data["content"]
   start_time = Time.now
@@ -72,6 +78,7 @@ post "/api/msgs/:username" do
 end
 
 get "/api/fllws/:username" do
+  env['sinatra.route'] = '/api/fllws/:username'
   limit = get_param_or_default("no", 100)
   start_time = Time.now
   followers = get_followers(params[:username], limit)
@@ -85,6 +92,7 @@ get "/api/fllws/:username" do
 end
 
 post "/api/fllws/:username" do
+  env['sinatra.route'] = '/api/fllws/:username'
   follow = @data["follow"].to_s
   unless follow.empty?
     follower_id = get_user_id(params[:username])


### PR DESCRIPTION
## What:

Fix so f.ex. /msgs appears as one metric for scraping instead of one for every user, i.e. /msgs/<username>.