### PR TITLE
Rsync grafana fix

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -51,7 +51,10 @@ jobs:
           chmod 600 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
-          
+      
+      - name: Debug Source Directory
+        run: ls -la /minitwit/grafana/provisioning/dashboards/
+
       - name: Sync Grafana Dashboards to Hot Server
         run: |
           rsync -avz -e "ssh -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no" 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -51,24 +51,17 @@ jobs:
           chmod 600 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
-      
-      - name: Debug Source Directory
-        run: ls -la /minitwit/grafana/provisioning/dashboards/
 
       - name: Sync Grafana Dashboards to Hot Server
         run: |
-          rsync -avz -e "ssh -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no" 
-          /minitwit/grafana/provisioning/dashboards/ 
-          $SSH_USER@$SSH_HOST:/minitwit/grafana/provisioning/dashboards/
+          rsync -avz -e "ssh -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no" ./grafana/provisioning/dashboards/ $SSH_USER@$SSH_HOST:/minitwit/grafana/provisioning/dashboards/
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
           
       - name: Sync Grafana Dashboards to Standby Server
         run: |
-          rsync -avz -e "ssh -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no" 
-          /minitwit/grafana/provisioning/dashboards/ 
-          $SSH_USER@$SSH_HOST2:/minitwit/grafana/provisioning/dashboards/
+          rsync -avz -e "ssh -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no" ./grafana/provisioning/dashboards/ $SSH_USER@$SSH_HOST2:/minitwit/grafana/provisioning/dashboards/
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST2: ${{ secrets.SSH_HOST2 }}


### PR DESCRIPTION
This pull request updates the deployment workflow for syncing Grafana dashboards to ensure the correct relative path is used during the `rsync` operation.

### Workflow improvements:
* Updated the `rsync` command in `.github/workflows/continuous-deployment.yml` to use the relative path `./grafana/provisioning/dashboards/` instead of the absolute path `/minitwit/grafana/provisioning/dashboards/` for both the hot server and standby server sync steps. This ensures consistency and avoids potential issues with absolute paths.