### PR TITLE
Added indexes to make /public faster

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,8 +32,6 @@ GEM
     bigdecimal (3.1.9)
     childprocess (5.1.0)
       logger (~> 1.5)
-    codeclimate-test-reporter (1.0.7)
-      simplecov
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.5)
@@ -126,7 +124,6 @@ GEM
       logger
       mime-types-data (~> 3.2015)
     mime-types-data (3.2025.0220)
-    mini_portile2 (2.8.8)
     minitest (5.25.4)
     multi_json (1.15.0)
     mustermann (3.0.3)
@@ -226,7 +223,14 @@ GEM
       simplecov (>= 0.22.0)
       tty-which (~> 0.5.0)
       virtus (~> 2.0)
+    rubyzip (2.4.1)
     securerandom (0.4.1)
+    selenium-webdriver (4.32.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sexp_processor (4.17.3)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -252,10 +256,6 @@ GEM
       rack-protection (= 4.1.1)
       sinatra (= 4.1.1)
       tilt (~> 2.0)
-    sqlite3 (2.5.0)
-      mini_portile2 (~> 2.8.0)
-    sqlite3 (2.5.0-x64-mingw-ucrt)
-    sqlite3 (2.5.0-x86_64-linux-gnu)
     standard (1.47.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -288,6 +288,7 @@ GEM
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
+    websocket (1.2.11)
     win32-file (0.8.2)
       ffi
       ffi-win32-extensions
@@ -306,7 +307,6 @@ DEPENDENCIES
   activerecord
   bcrypt
   bundler
-  codeclimate-test-reporter
   dawnscanner
   dotenv
   ffi
@@ -321,12 +321,11 @@ DEPENDENCIES
   rubocop
   rubycritic
   securerandom
-  simplecov
+  selenium-webdriver
   sinatra (~> 4.1)
   sinatra-activerecord
   sinatra-content-for
   sinatra-contrib
-  sqlite3
   standard
 
 BUNDLED WITH

--- a/db/migrate/20250503120534_add_indexes_to_messages.rb
+++ b/db/migrate/20250503120534_add_indexes_to_messages.rb
@@ -1,8 +1,8 @@
 class AddIndexesToMessages < ActiveRecord::Migration[6.1]
-    def change
-      add_index :messages, :flagged
-      add_index :messages, :author_id
-      add_index :messages, :pub_date
-      add_index :messages, [:flagged, :pub_date]
-    end
+  def change
+    add_index :messages, :flagged
+    add_index :messages, :author_id
+    add_index :messages, :pub_date
+    add_index :messages, [:flagged, :pub_date]
   end
+end

--- a/db/migrate/20250503120534_add_indexes_to_messages.rb
+++ b/db/migrate/20250503120534_add_indexes_to_messages.rb
@@ -1,0 +1,8 @@
+class AddIndexesToMessages < ActiveRecord::Migration[6.1]
+    def change
+      add_index :messages, :flagged
+      add_index :messages, :author_id
+      add_index :messages, :pub_date
+      add_index :messages, [:flagged, :pub_date]
+    end
+  end

--- a/remote_files/deploy.sh
+++ b/remote_files/deploy.sh
@@ -2,5 +2,6 @@ source ~/.bash_profile
 
 cd /minitwit
 
+docker compose -f docker-compose.yml down
 docker compose -f docker-compose.yml pull
 docker compose -f docker-compose.yml up -d


### PR DESCRIPTION
This pull request introduces database optimizations by adding indexes to the `messages` table and updates the deployment script to ensure a clean restart of services during deployment. These changes aim to improve query performance and enhance deployment reliability.

### Database optimizations:
* [`db/migrate/20250503120534_add_indexes_to_messages.rb`](diffhunk://#diff-d4fd4e5953cb0651e238bbe61110115883d868b151822988c741bbda9930aecaR1-R8): Added indexes to the `messages` table for the `flagged`, `author_id`, and `pub_date` columns, as well as a composite index for `flagged` and `pub_date`, to improve query performance.

### Deployment improvements:
* [`remote_files/deploy.sh`](diffhunk://#diff-218d97e9a7fe7df4e8b0cd5362ddb82b17d6759eb403883b499371516963aea4R5): Updated the deployment script to include a `docker compose down` command before pulling and starting services to ensure a clean restart.