### PR TITLE
Ignore environtment file when building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,3 +32,4 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.env


### PR DESCRIPTION
This pull request includes a small update to the `.dockerignore` file. The change adds `.env` to the list of ignored files to prevent sensitive environment variables from being included in Docker builds.