### PR TITLE
Update continuous-deployment.yml

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Sync docker-compose.yml to Hot Server
         run: |
-          rsync -avz -e "ssh -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no" ./docker-compose.yml $SSH_USER@$SSH_HOST2:/minitwit/
+          rsync -avz -e "ssh -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no" ./docker-compose.yml $SSH_USER@$SSH_HOST:/minitwit/
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST2: ${{ secrets.SSH_HOST }}


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/continuous-deployment.yml` file. The change updates the `rsync` command to use the correct `SSH_HOST` environment variable instead of `SSH_HOST2`, ensuring the `docker-compose.yml` file is synced to the intended server.